### PR TITLE
Add filename to non-inline warning messages

### DIFF
--- a/lib/xcprofiler/danger_reporter.rb
+++ b/lib/xcprofiler/danger_reporter.rb
@@ -14,11 +14,13 @@ module Danger
     def report!(executions)
       executions.each do |execution|
         options = {}
+        message = "`#{execution.method_name}` takes #{execution.time} ms to build"
         if @inline_mode
           options[:file] = relative_path(execution.path)
           options[:line] = execution.line
+        else
+          message = "`#{execution.method_name}` in `#{execution.filename}` takes #{execution.time} ms to build"
         end
-        message = "`#{execution.method_name}` takes #{execution.time} ms to build"
         if execution.time >= @thresholds[:fail]
           @dangerfile.fail(message, options)
         elsif execution.time >= @thresholds[:warn]

--- a/lib/xcprofiler/danger_reporter.rb
+++ b/lib/xcprofiler/danger_reporter.rb
@@ -14,13 +14,12 @@ module Danger
     def report!(executions)
       executions.each do |execution|
         options = {}
-        message = "`#{execution.method_name}` takes #{execution.time} ms to build"
         if @inline_mode
           options[:file] = relative_path(execution.path)
           options[:line] = execution.line
-        else
-          message = "`#{execution.method_name}` in `#{execution.filename}` takes #{execution.time} ms to build"
         end
+        message = message(execution)
+
         if execution.time >= @thresholds[:fail]
           @dangerfile.fail(message, options)
         elsif execution.time >= @thresholds[:warn]
@@ -30,6 +29,12 @@ module Danger
     end
 
     private
+
+    def message(execution)
+      message = "`#{execution.method_name}` takes #{execution.time} ms to build"
+      return message if @inline_mode
+      "[#{execution.filename}] #{message}"
+    end
 
     def relative_path(path)
       working_dir = Pathname.new(@working_dir)

--- a/spec/xcprofiler_spec.rb
+++ b/spec/xcprofiler_spec.rb
@@ -96,7 +96,7 @@ module Danger
           let(:time1) { 50 }
           it 'asserts warning' do
             @xcprofiler.report(product_name)
-            expect(@dangerfile).to have_received(:warn).with('`doSomething()` takes 50.0 ms to build', {})
+            expect(@dangerfile).to have_received(:warn).with('`doSomething()` in `Source.swift` takes 50.0 ms to build', {})
           end
         end
 
@@ -105,7 +105,7 @@ module Danger
           let(:time1) { 100 }
           it 'asserts failure' do
             @xcprofiler.report(product_name)
-            expect(@dangerfile).to have_received(:fail).with('`doSomething()` takes 100.0 ms to build', {})
+            expect(@dangerfile).to have_received(:fail).with('`doSomething()` in `Source.swift` takes 100.0 ms to build', {})
           end
         end
       end

--- a/spec/xcprofiler_spec.rb
+++ b/spec/xcprofiler_spec.rb
@@ -13,8 +13,8 @@ module Danger
       let(:profiler) { Xcprofiler::Profiler.new(derived_data) }
       let(:location) { 'path/to/Source.swift:20:30' }
       let(:method_name) { 'doSomething()' }
-      let(:time0) { 0 }
-      let(:time1) { 0 }
+      let(:time0) { 99.9 }
+      let(:time1) { 100 }
       let(:execution0) { Xcprofiler::Execution.new(time0, location, method_name) }
       let(:execution1) { Xcprofiler::Execution.new(time1, location, method_name) }
 
@@ -45,8 +45,6 @@ module Danger
       end
 
       context 'with very slow execution' do
-        let(:time0) { 99.9 }
-        let(:time1) { 100 }
         it 'asserts failure' do
           @xcprofiler.report(product_name)
           expect(@dangerfile).to have_received(:fail).with('`doSomething()` takes 100.0 ms to build',
@@ -96,16 +94,16 @@ module Danger
           let(:time1) { 50 }
           it 'asserts warning' do
             @xcprofiler.report(product_name)
-            expect(@dangerfile).to have_received(:warn).with('`doSomething()` in `Source.swift` takes 50.0 ms to build', {})
+            expect(@dangerfile).to have_received(:warn)
+              .with('[Source.swift] `doSomething()` takes 50.0 ms to build', {})
           end
         end
 
         context 'with very slow execution' do
-          let(:time0) { 99.9 }
-          let(:time1) { 100 }
           it 'asserts failure' do
             @xcprofiler.report(product_name)
-            expect(@dangerfile).to have_received(:fail).with('`doSomething()` in `Source.swift` takes 100.0 ms to build', {})
+            expect(@dangerfile).to have_received(:fail)
+              .with('[Source.swift] `doSomething()` takes 100.0 ms to build', {})
           end
         end
       end


### PR DESCRIPTION
When setting inline_mode to false, warning messages didn't include filename
makes it difficult to find the files with slow build time.