### PR TITLE
Allow custom derived data path and ignored_files support

### DIFF
--- a/lib/xcprofiler/danger_reporter.rb
+++ b/lib/xcprofiler/danger_reporter.rb
@@ -3,15 +3,18 @@ require 'pathname'
 
 module Danger
   class DangerReporter < Xcprofiler::AbstractReporter
-    def initialize(dangerfile, thresholds, inline_mode, working_dir)
+    def initialize(dangerfile, thresholds, inline_mode, working_dir, ignored_files)
       super({})
       @dangerfile = dangerfile
       @thresholds = thresholds
       @inline_mode = inline_mode
       @working_dir = working_dir
+      @ignored_files = ignored_files
     end
 
     def report!(executions)
+      executions.reject! { |execution| ignored_files.any? { |pattern| File.fnmatch(pattern, execution.path) } }
+
       if @inline_mode
         inline_report(executions)
       else
@@ -68,6 +71,10 @@ module Danger
       end
 
       message
+    end
+
+    def ignored_files
+      [@ignored_files].flatten.compact
     end
   end
 end

--- a/lib/xcprofiler/plugin.rb
+++ b/lib/xcprofiler/plugin.rb
@@ -37,6 +37,14 @@ module Danger
     # @return   [Boolean]
     attr_accessor :inline_mode
 
+    # A globbed string or array of strings which should match the files
+    # that you want to ignore warnings on. Defaults to nil.
+    # An example would be `'**/Pods/**'` to ignore warnings in Pods that your project uses.
+    #
+    # @param    [String or [String]] value
+    # @return   [[String]]
+    attr_accessor :ignored_files
+
     # Search the latest .xcactivitylog by the passing product_name and profile compilation time
     # @param    [String] product_name Product name for the target project.
     # @param    [String] derived_data_path Path to the directory containing the DerivedData.
@@ -44,7 +52,7 @@ module Danger
     def report(product_name, derived_data_path = nil)
       profiler = Xcprofiler::Profiler.by_product_name(product_name, derived_data_path)
       profiler.reporters = [
-        DangerReporter.new(@dangerfile, thresholds, inline_mode, working_dir)
+        DangerReporter.new(@dangerfile, thresholds, inline_mode, working_dir, ignored_files)
       ]
       profiler.report!
     rescue Xcprofiler::DerivedDataNotFound, Xcprofiler::BuildFlagIsNotEnabled => e
@@ -52,6 +60,10 @@ module Danger
     end
 
     private
+
+    def ignored_files
+      [@ignored_files].flatten.compact
+    end
 
     def working_dir
       @working_dir || Dir.pwd

--- a/lib/xcprofiler/plugin.rb
+++ b/lib/xcprofiler/plugin.rb
@@ -61,10 +61,6 @@ module Danger
 
     private
 
-    def ignored_files
-      [@ignored_files].flatten.compact
-    end
-
     def working_dir
       @working_dir || Dir.pwd
     end

--- a/lib/xcprofiler/plugin.rb
+++ b/lib/xcprofiler/plugin.rb
@@ -63,6 +63,7 @@ module Danger
 
     def inline_mode
       return true if @inline_mode.nil?
+
       !!@inline_mode
     end
   end

--- a/lib/xcprofiler/plugin.rb
+++ b/lib/xcprofiler/plugin.rb
@@ -12,6 +12,10 @@ module Danger
   #          xcprofiler.thresholds = { warn: 100, fail: 500 }
   #          xcprofiler.report 'MyApp'
   #
+  # @example Specify a custom DerivedData directory
+  #
+  #          xcprofiler.report 'MyApp' './DerivedData'
+  #
   # @see  giginet/danger-xcprofiler
   # @tags xcode, ios, danger
   class DangerXcprofiler < Plugin
@@ -35,9 +39,10 @@ module Danger
 
     # Search the latest .xcactivitylog by the passing product_name and profile compilation time
     # @param    [String] product_name Product name for the target project.
+    # @param    [String] derived_data_path Path to the directory containing the DerivedData.
     # @return   [void]
-    def report(product_name)
-      profiler = Xcprofiler::Profiler.by_product_name(product_name)
+    def report(product_name, derived_data_path = nil)
+      profiler = Xcprofiler::Profiler.by_product_name(product_name, derived_data_path)
       profiler.reporters = [
         DangerReporter.new(@dangerfile, thresholds, inline_mode, working_dir)
       ]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'coveralls'
 Coveralls.wear!
 
 require 'pathname'
-ROOT = Pathname.new(File.expand_path('../../', __FILE__))
+ROOT = Pathname.new(File.expand_path('..', __dir__))
 $LOAD_PATH.unshift((ROOT + 'lib').to_s)
 $LOAD_PATH.unshift((ROOT + 'spec').to_s)
 

--- a/spec/xcprofiler_spec.rb
+++ b/spec/xcprofiler_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../spec_helper', __FILE__)
+require File.expand_path('spec_helper', __dir__)
 require 'xcprofiler'
 
 module Danger

--- a/spec/xcprofiler_spec.rb
+++ b/spec/xcprofiler_spec.rb
@@ -1,6 +1,7 @@
 require File.expand_path('spec_helper', __dir__)
 require 'xcprofiler'
 
+# rubocop:disable Metrics/ModuleLength
 module Danger
   describe Danger::DangerXcprofiler do
     it 'should be a plugin' do
@@ -31,6 +32,25 @@ module Danger
         [execution0, execution1].each do |execution|
           allow(execution).to receive(:invalid?).and_return(false)
           allow(execution).to receive(:location).and_return(location)
+        end
+      end
+
+      context 'with ignored files' do
+        let(:time0) { 49.9 }
+        let(:time1) { 50 }
+        it 'skips matching warning' do
+          @xcprofiler.ignored_files = ['path/**']
+          @xcprofiler.report(product_name)
+          expect(@dangerfile).to_not have_received(:warn).with('`doSomething()` takes 50.0 ms to build',
+                                                               file: 'path/to/Source.swift',
+                                                               line: 20)
+        end
+        it 'includes non-matching warning' do
+          @xcprofiler.ignored_files = ['other/path/**']
+          @xcprofiler.report(product_name)
+          expect(@dangerfile).to have_received(:warn).with('`doSomething()` takes 50.0 ms to build',
+                                                           file: 'path/to/Source.swift',
+                                                           line: 20)
         end
       end
 
@@ -119,3 +139,4 @@ module Danger
     end
   end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/spec/xcprofiler_spec.rb
+++ b/spec/xcprofiler_spec.rb
@@ -25,7 +25,7 @@ module Danger
         allow(@dangerfile).to receive(:warn)
         allow(@dangerfile).to receive(:fail)
         allow(@dangerfile).to receive(:markdown)
-        allow(Xcprofiler::Profiler).to receive(:by_product_name).with(product_name).and_return(profiler)
+        allow(Xcprofiler::Profiler).to receive(:by_product_name).with(product_name, nil).and_return(profiler)
         allow(derived_data).to receive(:flag_enabled?).and_return(true)
         allow(derived_data).to receive(:executions).and_return([execution0, execution1])
         [execution0, execution1].each do |execution|


### PR DESCRIPTION
I'm setting up danger-xcprofiler on a Jenkins box, and we put the derived data in a different directory. The plugin doesn't allow you to specify a DerivedData directory, but xcprofiler does. This just relays through another string.

Additionally, we have a handful of errors in our Pods directory that I want to be able to ignore. So I added an `ignored_files` property to the plugin that mimics the behavior of `danger-xcode_summary` and allows a simple regular expression.